### PR TITLE
Hotfix session service

### DIFF
--- a/CoreGymApi/ISessionService.cs
+++ b/CoreGymApi/ISessionService.cs
@@ -1,0 +1,8 @@
+﻿using CoreGymApi.Entities;
+
+namespace CoreGymApi;
+
+public interface ISessionService
+{
+    List<Session> GetSessions();
+}

--- a/CoreGymApi/Program.cs
+++ b/CoreGymApi/Program.cs
@@ -1,91 +1,24 @@
+using CoreGymApi;
 using CoreGymApi.Entities;
+using CoreGymApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
+builder.Services.AddCors();
+builder.Services.AddScoped<ISessionService, SessionService>();
 
 var app = builder.Build();
 
 app.MapOpenApi();
 app.UseCors(c => c.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
-
-
 app.UseHttpsRedirection();
 
-var sessions = new List<Session>
-{
-    new Session
-    {
-        Id = Guid.NewGuid(),
-        StartTime = DateTime.Now,
-        Duration = 3,
-        Title = "Spinning",
-        Description = "",
-        Trainer = "Ove Persson",
-        Location = "Göteborg",
-        Spots = 20
-    },
-    new Session
-    {
-        Id = Guid.NewGuid(),
-        StartTime = DateTime.Now,
-        Duration = 2,
-        Title = "Aerobics",
-        Description = "",
-        Trainer = "Kent olsson",
-        Location = "Halmstad",
-        Spots = 20
-    },
-    new Session
-    {
-        Id = Guid.NewGuid(),
-        StartTime = DateTime.Now,
-        Duration = 3,
-        Title = "Cross Fit",
-        Description = "",
-        Trainer = "Kalle Stenhård",
-        Location = "Örebro",
-        Spots = 20
-    },
-     new Session
-    {
-        Id = Guid.NewGuid(),
-        StartTime = DateTime.Now.AddDays(1),
-        Duration = 3,
-        Title = "Spinning",
-        Description = "",
-        Trainer = "Ove Persson",
-        Location = "Göteborg",
-        Spots = 20
-    },
-    new Session
-    {
-        Id = Guid.NewGuid(),
-        StartTime = DateTime.Now.AddDays(1),
-        Duration = 2,
-        Title = "Aerobics",
-        Description = "",
-        Trainer = "Kent olsson",
-        Location = "Halmstad",
-        Spots = 20
-    },
-    new Session
-    {
-        Id = Guid.NewGuid(),
-        StartTime = DateTime.Now.AddDays(1),
-        Duration = 3,
-        Title = "Cross Fit",
-        Description = "",
-        Trainer = "Kalle Stenhård",
-        Location = "Örebro",
-        Spots = 20
-    }
-};
 
 
-app.MapGet("/sessions", () =>
+app.MapGet("/sessions", (ISessionService service) =>
 {
-    return sessions;
+    return service.GetSessions();
 })
 .WithName("GetTrainingSessions");
 

--- a/CoreGymApi/Services/SessionService.cs
+++ b/CoreGymApi/Services/SessionService.cs
@@ -1,0 +1,44 @@
+﻿using CoreGymApi.Entities;
+
+namespace CoreGymApi.Services;
+
+public class SessionService : ISessionService
+{
+    public List<Session> GetSessions()
+    {
+        var sessions = new List<Session>();
+        var startDate = new DateTime(2025, 9, 22);
+
+        var dailySchedule = new[]
+        {
+            new { Hour = 6, Minute = 0, Title = "Spinning", Trainer = "Ove Persson", Location = "Göteborg", Duration = 3 },
+            new { Hour = 8, Minute = 30, Title = "Aerobics", Trainer = "Kent Olsson", Location = "Halmstad", Duration = 2 },
+            new { Hour = 17, Minute = 0, Title = "Yoga", Trainer = "Anna Svensson", Location = "Stockholm", Duration = 1 },
+            new { Hour = 18, Minute = 30, Title = "CrossFit", Trainer = "Marcus Berg", Location = "Malmö", Duration = 2 }
+        };
+
+        for (int day = 0; day < 14; day++)
+        {
+            var currentDate = startDate.AddDays(day);
+
+            foreach (var schedule in dailySchedule)
+            {
+                sessions.Add(new Session
+                {
+                    Id = Guid.NewGuid(),
+                    StartTime = new DateTime(currentDate.Year, currentDate.Month, currentDate.Day,
+                                           schedule.Hour, schedule.Minute, 0),
+                    Duration = schedule.Duration,
+                    Title = schedule.Title,
+                    Description = "",
+                    Trainer = schedule.Trainer,
+                    Location = schedule.Location,
+                    Spots = 20
+                });
+            }
+        }
+
+
+        return sessions;
+    }
+}


### PR DESCRIPTION
Added CORS to allow all connections for testing
Added SessionService through dependency injection and a function taht generates 4 sessions per day over the span of 14 days. so we can test the MVP properly.